### PR TITLE
fix: zoom value from firebase

### DIFF
--- a/lib/core/services/controllers/horario_controller.dart
+++ b/lib/core/services/controllers/horario_controller.dart
@@ -56,6 +56,7 @@ class HorarioController {
 
   void init(BuildContext context){
     zoom.value = RemoteConfigService.horarioZoom;
+    zoom.value = 0.5;
     moveViewportToCurrentPeriodAndDay(context);
     setZoom(zoom.value);
     _setScrollControllerListeners();


### PR DESCRIPTION
- Se arregla el zoom extraido de firebase ya que se lo trae como 0 entonces no se muestra el horario, se dejo definido como 0.5 luego de iniciar el valor de firebase para que se vea, pero es una solucion parche