### PR TITLE
fix: asignatura button disappear in init state

### DIFF
--- a/lib/styles/navigation/bottom_navbar.dart
+++ b/lib/styles/navigation/bottom_navbar.dart
@@ -1,6 +1,8 @@
 import "package:flutter/material.dart";
+import "package:get/get.dart";
 import "package:miutem/core/models/navigation/navigation_item.dart";
 import "package:miutem/core/models/user/perfil.dart";
+import "package:miutem/core/services/auth_service.dart";
 import "package:miutem/screens/asignaturas/lista_asignaturas_screen.dart";
 import "package:miutem/screens/credencial/credencial_screen.dart";
 import "package:miutem/screens/home/home_screen.dart";
@@ -34,14 +36,29 @@ class _BottomNavBarState extends State<BottomNavBar> {
   @override
   void initState() {
     super.initState();
-    // Ensure the initial index is valid for enabled screens
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    // Hydrate auth cache first so profile-gated tabs are available on first render.
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final authService = Get.find<AuthService>();
+      if (authService.cachedEstudiante == null) {
+        try {
+          await authService.login();
+        } catch (_) {
+          // Keep current behavior when login state is not available yet.
+        }
+      }
+
+      if (!mounted) return;
+
       final enabled = enabledScreens;
       if (enabled.isNotEmpty && idx >= enabled.length) {
         setState(() {
-          idx = 0; // Reset to first available screen
+          idx = 0;
         });
+        return;
       }
+
+      // Rebuild once to reflect profile-based tabs after auth cache hydration.
+      setState(() {});
     });
   }
 

--- a/lib/styles/navigation/bottom_navbar.dart
+++ b/lib/styles/navigation/bottom_navbar.dart
@@ -42,8 +42,10 @@ class _BottomNavBarState extends State<BottomNavBar> {
       if (authService.cachedEstudiante == null) {
         try {
           await authService.login();
-        } catch (_) {
-          // Keep current behavior when login state is not available yet.
+        } catch (e, stackTrace) {
+          // Keep current behavior when login state is not available yet, but log unexpected failures.
+          debugPrint('Auth cache hydration failed in BottomNavBar.initState: $e');
+          debugPrint(stackTrace.toString());
         }
       }
 

--- a/lib/styles/navigation/bottom_navbar.dart
+++ b/lib/styles/navigation/bottom_navbar.dart
@@ -44,7 +44,7 @@ class _BottomNavBarState extends State<BottomNavBar> {
           await authService.login();
         } catch (e, stackTrace) {
           // Keep current behavior when login state is not available yet, but log unexpected failures.
-          debugPrint('Auth cache hydration failed in BottomNavBar.initState: $e');
+          debugPrint("Auth cache hydration failed in BottomNavBar.initState: $e");
           debugPrint(stackTrace.toString());
         }
       }


### PR DESCRIPTION
This pull request updates the initialization logic of the `BottomNavBar` to ensure that authentication data is loaded before rendering profile-gated tabs. The main focus is to hydrate the authentication cache on first render, so that navigation items dependent on the user's profile are properly displayed.

Key improvements to navigation initialization and authentication:

* In `lib/styles/navigation/bottom_navbar.dart`, the `initState` method now asynchronously hydrates the authentication cache using `AuthService` before building the navigation bar, ensuring that profile-dependent tabs are available on the initial render. It also handles the case where authentication data is not yet available, and forces a rebuild to reflect any changes.
* Added imports for `get`, `AuthService`, and related dependencies to support the new authentication logic.