### PR TITLE
fix: grammar mistake in spanish

### DIFF
--- a/lib/screens/home/widgets/acceso_rapido.dart
+++ b/lib/screens/home/widgets/acceso_rapido.dart
@@ -11,7 +11,7 @@ class AccesoRapido extends StatelessWidget {
   Widget build(BuildContext context) => Column(
     crossAxisAlignment: CrossAxisAlignment.start,
     children: [
-      Text("¿Que quieres hacer hoy?", style: Theme.of(context).textTheme.bodyMedium),
+      Text("¿Qué quieres hacer hoy?", style: Theme.of(context).textTheme.bodyMedium),
       Space.extraSmall,
       SizedBox(
         height: 130,


### PR DESCRIPTION
This pull request makes a minor correction to the user interface text in the `AccesoRapido` widget. The change fixes a typo in the displayed question to use the correct accent mark in Spanish.

- Corrected the displayed text in the `AccesoRapido` widget from "¿Que quieres hacer hoy?" to "¿Qué quieres hacer hoy?" to use the proper accent mark.