### PR TITLE
patch: ignora dependabot para el deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,8 @@ on:
           - development
 jobs:
   determine-environment:
+    # Los bumps de dependabot no despliegan. Al saltarse este job, los deploy-* que dependen de él también se saltan.
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.head_commit.author.username != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     outputs:
       environment: ${{ steps.set-environment.outputs.environment }}


### PR DESCRIPTION
Se ignorará push de dependabot en los deployments ya que deben ser probados primero