### PR TITLE
patch: se unifica el workflow de capturas y se agrega iPad

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -223,17 +223,26 @@ jobs:
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
 
-  # Las capturas van en jobs aparte y no dentro de deploy-*: corren en paralelo con el
-  # despliegue, no tocan la firma del binario que sí se publica y, si fallan, el release
-  # ya salió igual. Además necesitan otra configuración de firebase (Debug y los dos
+  # Las capturas van en un job aparte y no dentro de deploy-*: corre en paralelo con el
+  # despliegue, no toca la firma del binario que sí se publica y, si falla, el release
+  # ya salió igual. Además necesita otra configuración de firebase (Debug y los dos
   # entornos, porque `flutter drive` compila en debug y el test importa ambas opciones).
-  screenshots-ios:
+  #
+  # Las dos plataformas van en el mismo job (y el mismo runner de macOS): el simulador de
+  # iOS obliga a macOS, y ahí el emulador de Android también corre acelerado por hardware,
+  # así que sale más barato que mantener dos jobs con la misma preparación duplicada.
+  screenshots:
     needs: determine-environment
     runs-on: macos-latest
     environment: ${{ needs.determine-environment.outputs.environment }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     # Si contiene [skip deploy] o [skip screenshots] en el mensaje del commit, se saltará.
     if: ${{ !contains(github.event.head_commit.message, '[skip deploy]') && !contains(github.event.head_commit.message, '[skip screenshots]') }}
+    env:
+      # Los títulos de las capturas llevan tildes y el runner de macOS no define locale:
+      # frameit se cae al leer los .strings y termina sin enmarcar ninguna captura.
+      LANG: en_US.UTF-8
+      LC_ALL: en_US.UTF-8
     steps:
       - name: 📚 Clonar Repositorio
         uses: actions/checkout@v4
@@ -243,13 +252,21 @@ jobs:
         with:
           xcode-version: ${{ vars.XCODE_VERSION }}
 
+      - name: ☕ Configurar Java
+        # Gradle compila el APK de las capturas de Android; el JDK por defecto del runner
+        # de macOS no siempre es el que espera el Android Gradle Plugin.
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
       - name: ⚡ Configurar Cache para Flutter pub
         uses: actions/cache@v5
         with:
           path: |
             ~/.pub-cache
-          key: pub-cache-screenshots-ios-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: pub-cache-screenshots-ios-${{ runner.os }}-
+          key: pub-cache-screenshots-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: pub-cache-screenshots-${{ runner.os }}-
 
       - name: ⚡ Configurar Cache para CocoaPods
         uses: actions/cache@v5
@@ -257,8 +274,17 @@ jobs:
           path: |
             ios/Pods
             ~/.cocoapods
-          key: pods-screenshots-ios-${{ runner.os }}-${{ hashFiles('ios/Podfile.lock') }}
-          restore-keys: pods-screenshots-ios-${{ runner.os }}-
+          key: pods-screenshots-${{ runner.os }}-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: pods-screenshots-${{ runner.os }}-
+
+      - name: ⚡ Configurar Cache para Gradle
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-screenshots-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-screenshots-${{ runner.os }}-
 
       - name: 🪄 Instalar ImageMagick
         # frameit y los scripts de fondos y composición trabajan con `magick`.
@@ -301,108 +327,14 @@ jobs:
         # importa las opciones de firebase de los dos entornos.
         run: ./scripts/flutterfire-configure all --build-type=Debug
 
-      - name: 📸 Generar capturas de pantalla
+      - name: 📸 Generar capturas de iOS (iPhone y iPad)
         run: bundle exec fastlane ios screenshots
         env:
           APP_ENV: ${{ vars.APP_ENV }}
 
-      - name: 📤 Subir capturas como artefacto
-        id: artefacto
-        uses: actions/upload-artifact@v7
-        with:
-          name: capturas-ios
-          path: fastlane/screenshots/*/*.png
-          if-no-files-found: error
-
-      - name: 📝 Publicar capturas en el resumen
-        env:
-          ARTEFACTO_URL: ${{ steps.artefacto.outputs.artifact-url }}
-        run: |
-          {
-            echo "## 📸 Capturas de pantalla (iOS)"
-            echo ""
-            echo "- $(find fastlane/screenshots -name '*_framed.png' | wc -l | tr -d ' ') capturas enmarcadas para la App Store"
-            echo "- [Descargar artefacto]($ARTEFACTO_URL)"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  screenshots-android:
-    needs: determine-environment
-    runs-on: ubuntu-latest
-    environment: ${{ needs.determine-environment.outputs.environment }}
-    timeout-minutes: 60
-    # Igual que deploy-android, sólo producción: las capturas son las de la ficha de Play.
-    if: ${{ needs.determine-environment.outputs.environment == 'prod' && (!contains(github.event.head_commit.message, '[skip deploy]') && !contains(github.event.head_commit.message, '[skip screenshots]')) }}
-    steps:
-      - name: 📚 Clonar Repositorio
-        uses: actions/checkout@v4
-
-      - name: 🖥️ Habilitar KVM
-        # Sin esto el emulador arranca por software y el recorrido no alcanza a terminar.
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
-      - name: ⚡ Configurar Cache para Gradle
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-screenshots-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: gradle-screenshots-${{ runner.os }}-
-
-      - name: ⚡ Configurar Cache para Flutter pub
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.pub-cache
-          key: pub-cache-screenshots-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: pub-cache-screenshots-${{ runner.os }}-
-
-      - name: 🪄 Instalar ImageMagick
-        # frameit y los scripts de fondos y composición trabajan con `magick`, que sólo
-        # existe en ImageMagick 7: el paquete de apt es el 6 y deja únicamente `convert`.
-        # El binario oficial es un AppImage, así que también hace falta FUSE.
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libfuse2t64 || sudo apt-get install -y libfuse2
-          sudo curl -fsSL -o /usr/local/bin/magick https://imagemagick.org/archive/binaries/magick
-          sudo chmod +x /usr/local/bin/magick
-          magick -version
-
-      - name: 🐦 Configurar Flutter SDK
-        uses: flutter-actions/setup-flutter@v4
-        with:
-          cache: true
-          channel: ${{ vars.FLUTTER_CHANNEL }}
-          version: ${{ vars.FLUTTER_VERSION }}
-
-      - name: 💎 Configurar Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ vars.RUBY_VERSION }}
-          bundler-cache: true
-
-      - name: 🗳️ Instalar firebase-tools
-        run: npm install -g firebase-tools
-
-      - name: 📦 Instalar librerías
-        run: flutter pub get
-
-      - name: 🔥 Instalar FlutterFire
-        run: dart pub global activate flutterfire_cli
-
-      - name: 🪎 Configura bundle
-        run: bundle install
-
-      - name: 🔐 Configura credenciales de firebase
-        env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-        run: ./scripts/flutterfire-configure all --build-type=Debug
-
-      - name: 📸 Generar capturas de pantalla
+      - name: 📸 Generar capturas de Android
         # El lane reutiliza el emulador que deja levantado la acción en vez de arrancar uno.
+        # En los runners de macOS (Apple Silicon) la imagen del sistema tiene que ser arm64.
         uses: reactivecircus/android-emulator-runner@v2
         env:
           APP_ENV: ${{ vars.APP_ENV }}
@@ -410,7 +342,7 @@ jobs:
         with:
           api-level: 35
           target: google_apis
-          arch: x86_64
+          arch: arm64-v8a
           profile: pixel_6
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
@@ -420,8 +352,10 @@ jobs:
         id: artefacto
         uses: actions/upload-artifact@v7
         with:
-          name: capturas-android
-          path: android/fastlane/screenshots/*/*.png
+          name: capturas
+          path: |
+            fastlane/screenshots/*/*.png
+            android/fastlane/screenshots/*/*.png
           if-no-files-found: error
 
       - name: 📝 Publicar capturas en el resumen
@@ -429,8 +363,9 @@ jobs:
           ARTEFACTO_URL: ${{ steps.artefacto.outputs.artifact-url }}
         run: |
           {
-            echo "## 📸 Capturas de pantalla (Android)"
+            echo "## 📸 Capturas de pantalla"
             echo ""
+            echo "- $(find fastlane/screenshots -name '*_framed.png' | wc -l | tr -d ' ') capturas enmarcadas para la App Store"
             echo "- $(find android/fastlane/screenshots -name '*_framed.png' | wc -l | tr -d ' ') capturas enmarcadas para Google Play"
             echo "- [Descargar artefacto]($ARTEFACTO_URL)"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/fastlane/.env.example
+++ b/fastlane/.env.example
@@ -34,8 +34,9 @@ MATCH_GIT_BASIC_AUTHORIZATION=
 MATCH_TYPE="appstore"
 
 # Capturas de pantalla automatizadas (lane `ios screenshots`)
-# Simuladores a usar, separados por coma. El tamaño de 6.9" (iPhone 17/16 Pro Max) es el único obligatorio en la App Store.
-SCREENSHOT_DEVICES="iPhone 17 Pro Max"
+# Simuladores a usar, separados por coma (basta el prefijo del nombre). La App Store pide
+# el tamaño de 6.9" (iPhone 17/16 Pro Max) y uno de iPad de 13".
+SCREENSHOT_DEVICES="iPhone 17 Pro Max,iPad Air 13-inch"
 # Idioma de la ficha en App Store Connect. Define la subcarpeta en fastlane/screenshots/
 SCREENSHOT_LOCALE=es-MX
 # No se necesita ninguna cuenta: la app corre con los datos ficticios de lib/core/mock/

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -69,7 +69,7 @@ Construye y firma la app para distribución en iOS
 [bundle exec] fastlane ios screenshots
 ```
 
-Genera las capturas de pantalla de iPhone en el simulador y las guarda en fastlane/screenshots
+Genera las capturas de pantalla de iPhone y iPad en el simulador y las guarda en fastlane/screenshots
 
 ### ios upload_screenshots
 

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,16 +1,20 @@
 import "../fastlane/src/helpers.rb"
 
 require "json"
+require "tmpdir"
 
-# Busca el UDID de un simulador por nombre, prefiriendo el runtime de iOS más nuevo.
-def ios_simulator_udid(name)
+# Busca un simulador por nombre y devuelve [udid, nombre real], prefiriendo el runtime de
+# iOS más nuevo. El nombre puede ser un prefijo ("iPad Air 13-inch" toma el M2, M3 o M4
+# según el Xcode del runner, que cambia con cada versión).
+def ios_simulator(name)
   devices = JSON.parse(sh("xcrun", "simctl", "list", "devices", "available", "--json", log: false))["devices"]
   runtimes = devices.keys.sort_by { |runtime| runtime.scan(/\d+/).map(&:to_i) }.reverse
-  device = runtimes.flat_map { |runtime| devices[runtime] }.find { |d| d["name"] == name }
+  disponibles = runtimes.flat_map { |runtime| devices[runtime] }
+  device = disponibles.find { |d| d["name"] == name } || disponibles.find { |d| d["name"].start_with?(name) }
 
   UI.user_error!("❌ No existe el simulador '#{name}'. Créalo en Xcode o ajusta SCREENSHOT_DEVICES.") unless device
 
-  device["udid"]
+  [device["udid"], device["name"]]
 end
 
 platform :ios do
@@ -189,9 +193,12 @@ platform :ios do
   # igual para Android. Del flujo de snapshot sí se conserva todo lo demás —la carpeta
   # fastlane/screenshots/<idioma>/ y los nombres "<Dispositivo>-<pantalla>.png"— para que
   # frameit y deliver reconozcan el dispositivo sin configuración extra.
-  desc "Genera las capturas de pantalla de iPhone en el simulador y las guarda en fastlane/screenshots"
+  desc "Genera las capturas de pantalla de iPhone y iPad en el simulador y las guarda en fastlane/screenshots"
   lane :screenshots do |options|
-    devices = array_option(options, :devices, env_var: "SCREENSHOT_DEVICES", default: ["iPhone 17 Pro Max"])
+    # La App Store pide un juego por tamaño de pantalla: el iPhone más grande y un iPad de
+    # 13". El iPad Air es el único de ese tamaño que da 2048x2732, la resolución que frameit
+    # sabe enmarcar (los iPad Pro M4 en adelante dan 2064x2752 y frameit no los conoce).
+    devices = array_option(options, :devices, env_var: "SCREENSHOT_DEVICES", default: ["iPhone 17 Pro Max", "iPad Air 13-inch"])
     locale = string_option(options, :locale, env_var: "SCREENSHOT_LOCALE", default: "es-MX")
     app_env = string_option(options, :app_env, env_var: "APP_ENV", default: "prod")
     clear = bool_option(options, :clear, env_var: "SCREENSHOT_CLEAR", default: true)
@@ -211,14 +218,19 @@ platform :ios do
     Dir.glob(File.join(output_dir, "*.png")).each { |captura| File.delete(captura) } if clear
     FileUtils.mkdir_p(output_dir)
 
+    # Cada dispositivo se enmarca solo en la carpeta y recién al final se juntan todos: los
+    # fondos y el marco salen del tamaño de las capturas que estén ahí, así que mezclar
+    # iPhone con iPad dejaría a uno de los dos con los fondos recortados del otro.
+    listas = Dir.mktmpdir("miutem-capturas")
+
     devices.each do |device|
-      udid = ios_simulator_udid(device)
-      UI.message("📱 Preparando #{device} (#{udid})")
+      udid, nombre = ios_simulator(device)
+      UI.message("📱 Preparando #{nombre} (#{udid})")
       sh("xcrun", "simctl", "bootstatus", udid, "-b")
 
       ENV["SCREENSHOTS_DIR"] = output_dir
       # Mismo formato de nombre que usa snapshot: frameit y deliver deducen de ahí el dispositivo.
-      ENV["SCREENSHOT_PREFIX"] = "#{device}-"
+      ENV["SCREENSHOT_PREFIX"] = "#{nombre}-"
 
       # SCREENSHOT_MODE hace que la app use los datos ficticios de lib/core/mock/
       # en vez de conectarse a SIGA y Mi.UTEM: no se necesita ninguna cuenta real.
@@ -231,23 +243,36 @@ platform :ios do
         "--dart-define=SCREENSHOT_MODE=true",
         "--dart-define=SCREENSHOT_PROD=#{app_env == 'prod'}"
       )
+
+      # Un timeout del test igual reporta "All tests passed" sin escribir nada, así que se verifica el resultado.
+      capturas = Dir.glob(File.join(output_dir, "*.png"))
+      UI.user_error!("❌ No se generó ninguna captura de #{nombre}. Revisa el log de `flutter drive`.") if capturas.empty?
+
+      if frame
+        # Los fondos se cortan al tamaño exacto de las capturas: si cambia el simulador
+        # cambia el tamaño, y frameit recortaría las tiras y rompería la continuidad.
+        sh(File.join(root, "scripts", "generate-screenshot-backgrounds"), "ios")
+        frame_screenshots(path: screenshots_dir)
+        # Las dos primeras capturas no salen de la app: se componen aparte, y después de
+        # frameit porque escriben directamente sus *_framed.png.
+        sh(File.join(root, "scripts", "compose-store-screenshots"), "ios")
+
+        # frameit no falla cuando no puede leer los títulos (pasa si el locale no es UTF-8):
+        # simplemente no enmarca nada, y las capturas sin marco no sirven para la ficha.
+        enmarcadas = Dir.glob(File.join(output_dir, "*_framed.png"))
+        UI.user_error!("❌ frameit no generó ninguna captura enmarcada de #{nombre}.") if enmarcadas.empty?
+      end
+
+      Dir.glob(File.join(output_dir, "*.png")).each { |captura| FileUtils.mv(captura, listas) }
+      # Apagarlo libera la RAM del runner para el siguiente simulador (y para el emulador de Android).
+      sh("xcrun simctl shutdown #{udid} || true")
     end
 
-    # Un timeout del test igual reporta "All tests passed" sin escribir nada, así que se verifica el resultado.
+    Dir.glob(File.join(listas, "*.png")).each { |captura| FileUtils.mv(captura, output_dir) }
+    FileUtils.remove_entry(listas)
+
     capturas = Dir.glob(File.join(output_dir, "*.png"))
-    UI.user_error!("❌ No se generó ninguna captura. Revisa el log de `flutter drive`.") if capturas.empty?
-
     UI.success("✅ #{capturas.length} capturas guardadas en #{output_dir}")
-
-    if frame
-      # Los fondos se cortan al tamaño exacto de las capturas: si cambia el simulador
-      # cambia el tamaño, y frameit recortaría las tiras y rompería la continuidad.
-      sh(File.join(root, "scripts", "generate-screenshot-backgrounds"), "ios")
-      frame_screenshots(path: screenshots_dir)
-      # Las dos primeras capturas no salen de la app: se componen aparte, y después de
-      # frameit porque escriben directamente sus *_framed.png.
-      sh(File.join(root, "scripts", "compose-store-screenshots"), "ios")
-    end
   end
 
   desc "Sube a App Store Connect las capturas ya generadas (sin tocar el binario)"

--- a/scripts/compose-store-screenshots
+++ b/scripts/compose-store-screenshots
@@ -9,8 +9,8 @@
 #
 # Uso: scripts/compose-store-screenshots [ios|android|all]
 #
-# La plataforma importa porque en CI cada una corre en un job (y un runner) distinto: sin
-# el argumento, el job de iOS moriría buscando las capturas de Android y viceversa.
+# La plataforma importa porque cada una se compone al terminar su propio recorrido: sin el
+# argumento, el paso de iOS moriría buscando las capturas de Android y viceversa.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."


### PR DESCRIPTION
## Qué pasaba

El job `screenshots-android` fallaba al instalar ImageMagick: descargaba el binario oficial con `curl` desde `imagemagick.org/archive/binaries/magick` y esa URL ahora responde 404.

## Qué cambia

**Un solo job de capturas, en macOS.** `screenshots-ios` y `screenshots-android` se fusionan en `screenshots`, con la configuración que ya usaba iOS:

- ImageMagick vuelve a `brew install imagemagick`, que nunca dio problemas. Se va el `curl` roto y el step de KVM.
- El emulador de Android corre en el mismo runner con `arch: arm64-v8a` (los runners de macOS son Apple Silicon: la aceleración la da Hypervisor.framework, no KVM), más `setup-java 17` y caché de Gradle.
- Un solo artefacto `capturas` con las dos plataformas y un resumen combinado. El timeout sube a 90 minutos.

**El recorrido de iOS también pasa por un iPad**, para tener las capturas del ancho que pide la App Store:

- Se usa el **iPad Air 13"** y no el Pro: da 2048x2732, la única resolución de 13" que frameit sabe enmarcar (el Pro M4 en adelante da 2064x2752 y frameit responde `Unsupported screen size`).
- El nombre del simulador se busca por prefijo, así que `iPad Air 13-inch` toma el M2, M3 o M4 según el Xcode del runner.
- Cada dispositivo se enmarca solo en la carpeta y recién al final se juntan todos: los fondos se cortan al tamaño exacto de las capturas, y mezclar iPhone (1320x2868) con iPad (2048x2732) le rompería la continuidad a uno de los dos.

**Locale UTF-8 en el job.** Sin él frameit se cae al leer los `.strings` con tildes, el paso no falla y las capturas terminan sin marco. El lane de iOS ahora además verifica que se hayan generado `*_framed.png`, igual que ya hacía el de Android.

## Para el revisor

- Verifiqué localmente el tramo de iPad: el simulador da 2048x2732 y `generate-screenshot-backgrounds` + `frameit` + `compose-store-screenshots` dejan las 8 capturas enmarcadas correctas, con el marco de iPad.
- Lo que no se puede probar fuera de CI es el emulador de Android sobre macOS y el `flutter drive` completo: se ve en la primera corrida.
- **Cambio de comportamiento**: las capturas de Android ahora también se generan en `dev`. Antes ese job estaba limitado a `prod`; el job unificado usa la condición que tenía iOS. Sólo suben como artefacto, no se publican en Play.
- Las dos plataformas corren en el mismo runner de forma secuencial. Paralelizarlas de verdad implicaría volver a dos jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)