### PR TITLE
patch: se separan las capturas de Android a un runner con KVM

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -223,18 +223,22 @@ jobs:
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
 
-  # Las capturas van en un job aparte y no dentro de deploy-*: corre en paralelo con el
-  # despliegue, no toca la firma del binario que sí se publica y, si falla, el release
-  # ya salió igual. Además necesita otra configuración de firebase (Debug y los dos
+  # Las capturas van en jobs aparte y no dentro de deploy-*: corren en paralelo con el
+  # despliegue, no tocan la firma del binario que sí se publica y, si fallan, el release
+  # ya salió igual. Además necesitan otra configuración de firebase (Debug y los dos
   # entornos, porque `flutter drive` compila en debug y el test importa ambas opciones).
   #
-  # Las dos plataformas van en el mismo job (y el mismo runner de macOS): el simulador de
-  # iOS obliga a macOS, y ahí el emulador de Android también corre acelerado por hardware,
-  # así que sale más barato que mantener dos jobs con la misma preparación duplicada.
-  screenshots:
+  # Cada plataforma va en su propio runner: el simulador de iOS obliga a macOS, y el
+  # emulador de Android necesita virtualización anidada. Los runners de macOS son máquinas
+  # virtuales sobre Apple Silicon y ahí adentro Hypervisor.framework no está disponible, así
+  # que el emulador —da igual si la imagen es arm64— muere apenas arranca con
+  # "HVF error: HV_UNSUPPORTED" y la acción se queda esperando un boot que nunca llega.
+  # En Linux sí hay KVM, y de paso los dos recorridos corren en paralelo.
+  screenshots-ios:
     needs: determine-environment
     runs-on: macos-latest
     environment: ${{ needs.determine-environment.outputs.environment }}
+    # El recorrido corre dos veces (iPhone y iPad) y cada uno se lleva ~25 minutos.
     timeout-minutes: 90
     # Si contiene [skip deploy] o [skip screenshots] en el mensaje del commit, se saltará.
     if: ${{ !contains(github.event.head_commit.message, '[skip deploy]') && !contains(github.event.head_commit.message, '[skip screenshots]') }}
@@ -252,14 +256,6 @@ jobs:
         with:
           xcode-version: ${{ vars.XCODE_VERSION }}
 
-      - name: ☕ Configurar Java
-        # Gradle compila el APK de las capturas de Android; el JDK por defecto del runner
-        # de macOS no siempre es el que espera el Android Gradle Plugin.
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: "17"
-
       - name: ⚡ Configurar Cache para Flutter pub
         uses: actions/cache@v5
         with:
@@ -276,15 +272,6 @@ jobs:
             ~/.cocoapods
           key: pods-screenshots-${{ runner.os }}-${{ hashFiles('ios/Podfile.lock') }}
           restore-keys: pods-screenshots-${{ runner.os }}-
-
-      - name: ⚡ Configurar Cache para Gradle
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-screenshots-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: gradle-screenshots-${{ runner.os }}-
 
       - name: 🪄 Instalar ImageMagick
         # frameit y los scripts de fondos y composición trabajan con `magick`.
@@ -332,9 +319,123 @@ jobs:
         env:
           APP_ENV: ${{ vars.APP_ENV }}
 
+      - name: 📤 Subir capturas como artefacto
+        id: artefacto
+        uses: actions/upload-artifact@v7
+        with:
+          name: capturas-ios
+          path: fastlane/screenshots/*/*.png
+          if-no-files-found: error
+
+      - name: 📝 Publicar capturas en el resumen
+        env:
+          ARTEFACTO_URL: ${{ steps.artefacto.outputs.artifact-url }}
+        run: |
+          {
+            echo "## 📸 Capturas de pantalla (iOS)"
+            echo ""
+            echo "- $(find fastlane/screenshots -name '*_framed.png' | wc -l | tr -d ' ') capturas enmarcadas para la App Store"
+            echo "- [Descargar artefacto]($ARTEFACTO_URL)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  screenshots-android:
+    needs: determine-environment
+    runs-on: ubuntu-latest
+    environment: ${{ needs.determine-environment.outputs.environment }}
+    timeout-minutes: 60
+    # Si contiene [skip deploy] o [skip screenshots] en el mensaje del commit, se saltará.
+    if: ${{ !contains(github.event.head_commit.message, '[skip deploy]') && !contains(github.event.head_commit.message, '[skip screenshots]') }}
+    env:
+      # Los títulos llevan tildes y frameit los lee con el encoding del entorno: si no es
+      # UTF-8 no falla, simplemente deja las capturas sin enmarcar. C.UTF-8 siempre existe
+      # en Ubuntu, a diferencia de en_US.UTF-8, que hay que generar.
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
+    steps:
+      - name: 📚 Clonar Repositorio
+        uses: actions/checkout@v4
+
+      - name: 🖥️ Habilitar KVM
+        # Sin esto el emulador arranca por software y el recorrido no alcanza a terminar.
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: ☕ Configurar Java
+        # Gradle compila el APK de las capturas; se fija el JDK en vez de depender del que
+        # traiga por defecto la imagen del runner, que cambia entre versiones.
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: ⚡ Configurar Cache para Gradle
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-screenshots-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-screenshots-${{ runner.os }}-
+
+      - name: ⚡ Configurar Cache para Flutter pub
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.pub-cache
+          key: pub-cache-screenshots-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: pub-cache-screenshots-${{ runner.os }}-
+
+      - name: 🪄 Instalar ImageMagick
+        # frameit y los scripts de fondos y composición trabajan con `magick`, que sólo
+        # existe en ImageMagick 7: el paquete de apt sigue en el 6 y deja únicamente
+        # `convert`. El runner ya trae Homebrew (instalado pero fuera del PATH) y su
+        # fórmula sí es la 7, así que se instala igual que en macOS y se enlaza sólo el
+        # binario, para no meter todo el prefijo de brew delante del PATH del resto del job.
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_NO_INSTALL_CLEANUP: "1"
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          brew install imagemagick
+          sudo ln -sf "$HOMEBREW_PREFIX/bin/magick" /usr/local/bin/magick
+          magick -version
+
+      - name: 🐦 Configurar Flutter SDK
+        uses: flutter-actions/setup-flutter@v4
+        with:
+          cache: true
+          channel: ${{ vars.FLUTTER_CHANNEL }}
+          version: ${{ vars.FLUTTER_VERSION }}
+
+      - name: 💎 Configurar Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ vars.RUBY_VERSION }}
+          bundler-cache: true
+
+      - name: 🗳️ Instalar firebase-tools
+        run: npm install -g firebase-tools
+
+      - name: 📦 Instalar librerías
+        run: flutter pub get
+
+      - name: 🔥 Instalar FlutterFire
+        run: dart pub global activate flutterfire_cli
+
+      - name: 🪎 Configura bundle
+        run: bundle install
+
+      - name: 🔐 Configura credenciales de firebase
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        # `all` y Debug: `flutter drive` compila en debug y integration_test/screenshots_test.dart
+        # importa las opciones de firebase de los dos entornos.
+        run: ./scripts/flutterfire-configure all --build-type=Debug
+
       - name: 📸 Generar capturas de Android
         # El lane reutiliza el emulador que deja levantado la acción en vez de arrancar uno.
-        # En los runners de macOS (Apple Silicon) la imagen del sistema tiene que ser arm64.
         uses: reactivecircus/android-emulator-runner@v2
         env:
           APP_ENV: ${{ vars.APP_ENV }}
@@ -342,7 +443,7 @@ jobs:
         with:
           api-level: 35
           target: google_apis
-          arch: arm64-v8a
+          arch: x86_64
           profile: pixel_6
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
@@ -352,10 +453,8 @@ jobs:
         id: artefacto
         uses: actions/upload-artifact@v7
         with:
-          name: capturas
-          path: |
-            fastlane/screenshots/*/*.png
-            android/fastlane/screenshots/*/*.png
+          name: capturas-android
+          path: android/fastlane/screenshots/*/*.png
           if-no-files-found: error
 
       - name: 📝 Publicar capturas en el resumen
@@ -363,9 +462,8 @@ jobs:
           ARTEFACTO_URL: ${{ steps.artefacto.outputs.artifact-url }}
         run: |
           {
-            echo "## 📸 Capturas de pantalla"
+            echo "## 📸 Capturas de pantalla (Android)"
             echo ""
-            echo "- $(find fastlane/screenshots -name '*_framed.png' | wc -l | tr -d ' ') capturas enmarcadas para la App Store"
             echo "- $(find android/fastlane/screenshots -name '*_framed.png' | wc -l | tr -d ' ') capturas enmarcadas para Google Play"
             echo "- [Descargar artefacto]($ARTEFACTO_URL)"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: miutem
 description: "Plataforma académica para estudiantes de la Universidad Tecnológica Metropolitana (UTEM)"
 publish_to: none
 
-version: 4.0.0+154
+version: 4.0.0+155
 
 environment:
   sdk: ^3.11.1


### PR DESCRIPTION
El job unificado de capturas moría en "Timeout waiting for emulator to boot": los runners de macOS son máquinas virtuales sobre Apple Silicon y adentro no hay Hypervisor.framework, así que el emulador se cae al arrancar con "HVF error: HV_UNSUPPORTED" —da igual que la imagen del sistema sea arm64— y la acción se queda esperando un boot que no llega.

Se vuelve a separar en screenshots-ios (macOS, simulador) y screenshots-android (Ubuntu, KVM), que además corren en paralelo en vez de uno detrás del otro.

De paso se repara el paso de ImageMagick del runner de Linux, que quedó fallando desde antes: el AppImage de imagemagick.org ya no existe (404) y el paquete de apt sigue en la versión 6, que no trae `magick`. Se instala con el Homebrew que ya viene en la imagen del runner y se enlaza sólo el binario, para no anteponer todo el prefijo de brew al PATH del resto del job.