### PR TITLE
patch: se reparan las capturas de Android en el runner de Ubuntu

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -391,16 +391,24 @@ jobs:
         # frameit y los scripts de fondos y composición trabajan con `magick`, que sólo
         # existe en ImageMagick 7: el paquete de apt sigue en el 6 y deja únicamente
         # `convert`. El runner ya trae Homebrew (instalado pero fuera del PATH) y su
-        # fórmula sí es la 7, así que se instala igual que en macOS y se enlaza sólo el
-        # binario, para no meter todo el prefijo de brew delante del PATH del resto del job.
+        # fórmula sí es la 7, así que se instala igual que en macOS y se enlazan sólo los
+        # binarios, para no meter todo el prefijo de brew delante del PATH del resto del job.
+        #
+        # `convert` va aunque nadie lo llame: es el binario de ImageMagick 6 y frameit lo
+        # sigue buscando para decidir si tiene con qué trabajar, así que sin él el
+        # `fastlane frameit` de scripts/compose-store-screenshots se niega a partir.
         env:
           HOMEBREW_NO_AUTO_UPDATE: "1"
           HOMEBREW_NO_INSTALL_CLEANUP: "1"
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           brew install imagemagick
-          sudo ln -sf "$HOMEBREW_PREFIX/bin/magick" /usr/local/bin/magick
-          magick -version
+          for binario in magick convert; do
+            sudo ln -sf "$HOMEBREW_PREFIX/bin/$binario" "/usr/local/bin/$binario"
+          done
+          # Por la ruta enlazada, que es la que ven los pasos siguientes (sin el PATH de brew).
+          /usr/local/bin/magick -version
+          /usr/local/bin/convert -version
 
       - name: 🐦 Configurar Flutter SDK
         uses: flutter-actions/setup-flutter@v4

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -48,8 +48,6 @@ android {
         ?: (keystoreProperties["keyPassword"] as String?)
     val useDebugSigning = System.getenv("MIUTEM_USE_DEBUG_SIGNING")?.toBoolean() ?: false
 
-    val debugKeystore = file("${System.getProperty("user.home")}/.android/debug.keystore")
-
     signingConfigs {
         create("release") {
             keyAlias = resolvedKeyAlias
@@ -57,11 +55,18 @@ android {
             storeFile = resolvedStoreFile?.let { file(it) }
             storePassword = resolvedStorePassword
         }
+        // Sin keystore propio se deja el `debug` tal cual lo trae AGP, que apunta a
+        // ~/.android/debug.keystore y lo crea la primera vez que lo necesita. Fijarle el
+        // `storeFile` a mano lo convierte en un keystore del usuario y Gradle exige que ya
+        // exista: en una máquina limpia —los runners de CI lo son— el build muere con
+        // "Keystore file '~/.android/debug.keystore' not found for signing config 'debug'".
         getByName("debug") {
-            keyAlias = if (useDebugSigning) "androiddebugkey" else (resolvedKeyAlias ?: "androiddebugkey")
-            keyPassword = if (useDebugSigning) "android" else (resolvedKeyPassword ?: "android")
-            storeFile = if (useDebugSigning) debugKeystore else (resolvedStoreFile?.let { file(it) } ?: debugKeystore)
-            storePassword = if (useDebugSigning) "android" else (resolvedStorePassword ?: "android")
+            if (!useDebugSigning && resolvedStoreFile != null) {
+                keyAlias = resolvedKeyAlias ?: "androiddebugkey"
+                keyPassword = resolvedKeyPassword ?: "android"
+                storeFile = file(resolvedStoreFile)
+                storePassword = resolvedStorePassword ?: "android"
+            }
         }
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: miutem
 description: "Plataforma académica para estudiantes de la Universidad Tecnológica Metropolitana (UTEM)"
 publish_to: none
 
-version: 4.0.0+156
+version: 4.0.0+157
 
 environment:
   sdk: ^3.11.1

--- a/scripts/compose-store-screenshots
+++ b/scripts/compose-store-screenshots
@@ -71,10 +71,19 @@ componer() {
     \( "$SPLASH_MARCA" -resize "$((ancho * 26 / 100))x" \) -gravity south -geometry "+0+$((alto * 5 / 100))" -composite \
     "$tmp/${prefijo}splash.png"
 
-  # 2. El marco del teléfono, prestado de frameit.
-  (cd "$tmp" && fastlane frameit ${plataforma:+"$plataforma"} >/dev/null 2>&1)
+  # 2. El marco del teléfono, prestado de frameit. La salida se guarda en vez de tirarla:
+  # frameit es ruidoso cuando funciona, pero cuando no (le falta ImageMagick, no puede
+  # bajar los marcos) es lo único que dice por qué, y `set -e` cortaría acá sin abrir la boca.
+  local bitacora="$tmp/frameit.log"
+  (cd "$tmp" && fastlane frameit ${plataforma:+"$plataforma"} >"$bitacora" 2>&1) || true
+
   local telefono="$tmp/${prefijo}splash_framed.png"
-  [ -f "$telefono" ] || { echo "❌ frameit no dejó el marco en $telefono" >&2; rm -rf "$tmp"; exit 1; }
+  if [ ! -f "$telefono" ]; then
+    echo "❌ frameit no dejó el marco en $telefono" >&2
+    tail -20 "$bitacora" >&2
+    rm -rf "$tmp"
+    exit 1
+  fi
 
   # 3. El lienzo de las dos capturas juntas, con el trozo de foto de fondo que les toca.
   magick "$base/backgrounds/01_bienvenida.jpg" "$base/backgrounds/02_bienvenida.jpg" +append "$tmp/lienzo.png"


### PR DESCRIPTION
El job `screenshots-android` no estaba generando ninguna captura. Había dos fallas, no una: la segunda venía justo detrás y habría reventado el job igual unos minutos después.

## 1. El keystore de debug

`flutter drive` moría en el build:

```
Execution failed for task ':app:validateSigningDevelopmentDebug'.
> Keystore file '/home/runner/.android/debug.keystore' not found for signing config 'debug'.
```

El bloque `debug` de `signingConfigs` le fijaba el `storeFile` a mano. Con eso AGP deja de tratarlo como *su* keystore de debug —el que crea solo la primera vez que lo necesita— y pasa a exigir un archivo ya existente. En una máquina limpia, y los runners lo son, ese archivo no está. No faltaba un paso en el workflow: Gradle lo habría creado si no le hubiéramos puesto la ruta encima.

Ahora el bloque sólo se toca cuando hay un keystore propio que usar, así que firmar el debug con la llave de release sigue igual y el resto cae en el config por defecto. De paso queda arreglado `flutter run` en una máquina que nunca abrió Android Studio, que fallaba con el mismo error.

## 2. Falta `convert` para frameit

El job recién se mudó a Ubuntu en #146, así que los pasos de post-proceso nunca habían corrido en Linux. `scripts/compose-store-screenshots` moría **en silencio**: el chequeo de dependencias de frameit busca `convert` (el binario de ImageMagick 6) y el paso de ImageMagick sólo enlaza `magick`. En macOS no se nota porque brew deja los dos en el PATH.

Se enlaza también `convert`, y la verificación pasa a hacerse por la ruta enlazada, que es la que ven los pasos siguientes.

Ese error además era invisible: la salida de frameit se mandaba a `/dev/null` y `set -e` cortaba el script sin decir nada. Ahora se guarda y se muestra cuando el marco no aparece.

## Cómo se probó

Los pasos del workflow se corrieron en una VM Linux con el mismo toolchain (Flutter 3.44.9, JDK 17, AGP 8.12 / Gradle 9.5.1), partiendo por reproducir el error original tal cual.

Firma, con el APK compilado en cada caso:

| Caso | Resultado |
|---|---|
| `MIUTEM_USE_DEBUG_SIGNING=true`, sin keystore (lane de capturas) | AGP crea `~/.android/debug.keystore`; APK firmado con `CN=Android Debug, O=Android, C=US` |
| Sin variables (máquina limpia, `flutter run`) | Igual; antes también fallaba acá |
| Con keystore de release, build debug | Firma con esa llave, comportamiento previo intacto |
| Con keystore de release, build release | Sin cambios |

El APK completo se compiló con el mismo target que usa `flutter drive` (`integration_test/screenshots_test.dart`, flavor `development`): `✓ Built app-development-debug.apk`, package `cl.inndev.miutem.dev`.

Post-proceso, con capturas sintéticas de 1080x2160 en `es-419`: `generate-screenshot-backgrounds` y `frame_screenshots` corren bien, y `compose-store-screenshots` deja las 8 capturas enmarcadas —incluidas la 01 y 02, que se componen aparte— con las tildes bien renderizadas bajo `LANG=C.UTF-8`. También se probó el camino de error escondiendo `convert`: ahora sí explica por qué se cayó.

**Queda sin probar** el recorrido dentro del emulador, porque la VM no tiene KVM. Se verificó todo lo anterior (build y firma) y todo lo posterior (fondos, frameit, composición).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrzSFvPqQ6gMjYFB1dNQAK)_