### PR TITLE
feat: se agregan las capturas de macOS y se enriquecen los datos

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -228,7 +228,8 @@ jobs:
   # ya salió igual. Además necesitan otra configuración de firebase (Debug y los dos
   # entornos, porque `flutter drive` compila en debug y el test importa ambas opciones).
   #
-  # Cada plataforma va en su propio runner: el simulador de iOS obliga a macOS, y el
+  # Cada plataforma va en su propio runner: el simulador de iOS y la app de macOS obligan
+  # a un runner de macOS, y el
   # emulador de Android necesita virtualización anidada. Los runners de macOS son máquinas
   # virtuales sobre Apple Silicon y ahí adentro Hypervisor.framework no está disponible, así
   # que el emulador —da igual si la imagen es arm64— muere apenas arranca con
@@ -473,6 +474,100 @@ jobs:
             echo "## 📸 Capturas de pantalla (Android)"
             echo ""
             echo "- $(find android/fastlane/screenshots -name '*_framed.png' | wc -l | tr -d ' ') capturas enmarcadas para Google Play"
+            echo "- [Descargar artefacto]($ARTEFACTO_URL)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  screenshots-macos:
+    needs: determine-environment
+    runs-on: macos-latest
+    environment: ${{ needs.determine-environment.outputs.environment }}
+    timeout-minutes: 60
+    # Si contiene [skip deploy] o [skip screenshots] en el mensaje del commit, se saltará.
+    if: ${{ !contains(github.event.head_commit.message, '[skip deploy]') && !contains(github.event.head_commit.message, '[skip screenshots]') }}
+    steps:
+      - name: 📚 Clonar Repositorio
+        uses: actions/checkout@v4
+
+      - name: ⚒️ Configurar Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ vars.XCODE_VERSION }}
+
+      - name: ⚡ Configurar Cache para Flutter pub
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.pub-cache
+          key: pub-cache-screenshots-macos-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: pub-cache-screenshots-macos-${{ runner.os }}-
+
+      - name: ⚡ Configurar Cache para CocoaPods
+        uses: actions/cache@v5
+        with:
+          path: |
+            macos/Pods
+            ~/.cocoapods
+          key: pods-screenshots-macos-${{ runner.os }}-${{ hashFiles('macos/Podfile.lock') }}
+          restore-keys: pods-screenshots-macos-${{ runner.os }}-
+
+      - name: 🐦 Configurar Flutter SDK
+        uses: flutter-actions/setup-flutter@v4
+        with:
+          cache: true
+          channel: ${{ vars.FLUTTER_CHANNEL }}
+          version: ${{ vars.FLUTTER_VERSION }}
+
+      - name: 💎 Configurar Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ vars.RUBY_VERSION }}
+          bundler-cache: true
+
+      - name: 🗳️ Instalar firebase-tools
+        run: npm install -g firebase-tools
+
+      - name: 📦 Instalar librerías
+        run: flutter pub get
+
+      - name: 🔥 Instalar FlutterFire
+        run: dart pub global activate flutterfire_cli
+
+      # flutterfire configure invoca `ruby -e "require 'xcodeproj'"` fuera de bundler, así
+      # que la gem tiene que estar instalada global (igual que en deploy-ios y deploy-macos).
+      - name: 💍 Instala gem xcodeproj
+        run: sudo gem install xcodeproj
+
+      - name: 🪎 Configura bundle
+        run: bundle install
+
+      - name: 🔐 Configura credenciales de firebase
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        # `all` y Debug: `flutter drive` compila en debug y integration_test/screenshots_test.dart
+        # importa las opciones de firebase de los dos entornos.
+        run: ./scripts/flutterfire-configure all --build-type=Debug
+
+      - name: 📸 Generar capturas de macOS
+        run: bundle exec fastlane mac screenshots
+        env:
+          APP_ENV: ${{ vars.APP_ENV }}
+
+      - name: 📤 Subir capturas como artefacto
+        id: artefacto
+        uses: actions/upload-artifact@v7
+        with:
+          name: capturas-macos
+          path: macos/fastlane/screenshots/*/*.png
+          if-no-files-found: error
+
+      - name: 📝 Publicar capturas en el resumen
+        env:
+          ARTEFACTO_URL: ${{ steps.artefacto.outputs.artifact-url }}
+        run: |
+          {
+            echo "## 📸 Capturas de pantalla (macOS)"
+            echo ""
+            echo "- $(find macos/fastlane/screenshots -name '*.png' | wc -l | tr -d ' ') capturas de 2880x1800 para la Mac App Store"
             echo "- [Descargar artefacto]($ARTEFACTO_URL)"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/fastlane/.env.example
+++ b/fastlane/.env.example
@@ -51,6 +51,11 @@ PLAY_SCREENSHOT_LOCALE=es-419
 # Marco de frameit para Android. Vacío = lo elige según el tamaño de la captura.
 SCREENSHOT_ANDROID_FRAME=
 
+# Capturas de pantalla automatizadas (lane `mac screenshots`)
+# Tamaño de la ventana en puntos. El recorrido rasteriza al doble, así que 1440x900 da
+# capturas de 2880x1800, una de las formas que acepta la Mac App Store.
+SCREENSHOT_MACOS_SIZE=1440x900
+
 # App Store Connect API Key configuration for iOS app distribution
 APP_STORE_CONNECT_API_KEY_ID=
 APP_STORE_CONNECT_ISSUER_ID=

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -209,6 +209,14 @@ Compila la app con flutter para macOS
 
 Construye y firma la app para distribución en macOS
 
+### mac screenshots
+
+```sh
+[bundle exec] fastlane mac screenshots
+```
+
+Genera las capturas de pantalla de macOS y las guarda en macos/fastlane/screenshots
+
 ### mac load_api_key
 
 ```sh

--- a/integration_test/screenshots_test.dart
+++ b/integration_test/screenshots_test.dart
@@ -1,7 +1,9 @@
 import "dart:io";
+import "dart:ui" as ui;
 
 import "package:adaptive_theme/adaptive_theme.dart";
 import "package:flutter/material.dart";
+import "package:flutter/rendering.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:integration_test/integration_test.dart";
 import "package:miutem/firebase_options_dev.dart" as dev;
@@ -176,6 +178,11 @@ Future<void> capturar(WidgetTester tester, IntegrationTestWidgetsFlutterBinding 
   FocusManager.instance.primaryFocus?.unfocus();
   await esperar(tester, const Duration(seconds: 2));
 
+  if (Platform.isMacOS) {
+    await capturarDesdeFlutter(tester, binding, archivo);
+    return;
+  }
+
   // La captura nativa de iOS usa `drawViewHierarchyInRect:afterScreenUpdates:YES`, que espera
   // un frame nuevo. El binding de tests sólo dibuja cuando se le pide, así que hay que seguir
   // bombeando mientras se espera la respuesta del canal o se produce un deadlock.
@@ -185,5 +192,46 @@ Future<void> capturar(WidgetTester tester, IntegrationTestWidgetsFlutterBinding 
     await tester.pump(const Duration(milliseconds: 50));
   }
   await captura;
+  paso(binding, "capturada $archivo");
+}
+
+/// Ancho en píxeles de las capturas de macOS. La Mac App Store sólo acepta 1280x800,
+/// 1440x900, 2560x1600 y 2880x1800: la ventana se abre en 1440x900 (MIUTEM_WINDOW_SIZE)
+/// y acá se rasteriza al doble, así el resultado calza con 2880x1800 sin recortar nada.
+const double anchoCapturaMacOS = 2880;
+
+/// Captura la ventana desde el árbol de Flutter y la deja en `reportData`, que es de donde
+/// el driver escribe los archivos (misma llave que usa `binding.takeScreenshot`).
+///
+/// En macOS el plugin de integration_test sólo responde `allTestsFinished`: no implementa
+/// `captureScreenshot`, así que la captura nativa devuelve MissingPluginException. Rasterizar
+/// la capa raíz da lo mismo en pantalla y además deja elegir la resolución de salida.
+Future<void> capturarDesdeFlutter(WidgetTester tester, IntegrationTestWidgetsFlutterBinding binding, String archivo) async {
+  final vista = tester.binding.renderViews.first;
+  final capa = vista.debugLayer! as OffsetLayer;
+
+  ui.Image? imagen;
+  var listo = false;
+  // Igual que en iOS: el binding sólo dibuja cuando se le pide, así que se sigue bombeando
+  // mientras el rasterizado está en curso. Se espera por `listo` y no por la imagen, para
+  // que un error corte el bucle y salga por el `await` de abajo.
+  final render = capa
+      .toImage(vista.paintBounds, pixelRatio: anchoCapturaMacOS / vista.paintBounds.width)
+      .then((resultado) => imagen = resultado)
+      .whenComplete(() => listo = true);
+  while (!listo) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+  await render;
+
+  final bytes = await imagen!.toByteData(format: ui.ImageByteFormat.png);
+  imagen!.dispose();
+
+  binding.reportData ??= <String, dynamic>{};
+  final capturas = binding.reportData!["screenshots"] ??= <dynamic>[];
+  (capturas as List<dynamic>).add(<String, dynamic>{
+    "screenshotName": archivo,
+    "bytes": bytes!.buffer.asUint8List(),
+  });
   paso(binding, "capturada $archivo");
 }

--- a/lib/core/mock/mock_data.dart
+++ b/lib/core/mock/mock_data.dart
@@ -73,26 +73,85 @@ final Asignatura practicaProfesional = Asignatura(
   intentos: 1,
 );
 
+final Asignatura computacionWebYMovil = Asignatura(
+  id: "1004",
+  codigo: "INFB8004",
+  nombre: "Computación Web y Móvil",
+  tipoHora: "Cátedra",
+  estado: "Inscrito",
+  seccion: "304",
+  docente: Persona(nombreCompleto: "Ignacio Salinas Bravo"),
+  tipoAsignatura: "Obligatoria",
+  sala: "M1 - 303",
+  intentos: 1,
+);
+
+final Asignatura gestionDeProyectos = Asignatura(
+  id: "1005",
+  codigo: "INFB8003",
+  nombre: "Gestión de Proyectos Informáticos",
+  tipoHora: "Cátedra",
+  estado: "Inscrito",
+  seccion: "301",
+  docente: Persona(nombreCompleto: "Marcela Tapia Reyes"),
+  tipoAsignatura: "Obligatoria",
+  sala: "M2 - 201",
+  intentos: 1,
+);
+
+final Asignatura electivoEspecializacion = Asignatura(
+  id: "1006",
+  codigo: "ELEC8050",
+  nombre: "Electivo de Formación Especializada II",
+  tipoHora: "Cátedra",
+  estado: "Inscrito",
+  seccion: "101",
+  docente: Persona(nombreCompleto: "Hernán Pimentel Torrejón"),
+  tipoAsignatura: "Electivo",
+  sala: "M3 - 303",
+  intentos: 1,
+);
+
 final List<Asignatura> asignaturasMock = [
   computacionEnLaNube,
   trabajoDeTitulo,
   practicaProfesional,
+  computacionWebYMovil,
+  gestionDeProyectos,
+  electivoEspecializacion,
 ];
 
 /// Clases de la semana como (período 1..9, día 1..6, asignatura).
-/// El lunes concentra las tres asignaturas para que "Clases de Hoy" no quede vacío.
+///
+/// Seis asignaturas repartidas de lunes a viernes: el horario recibe un color por
+/// asignatura, así que mientras más variadas las clases del día, más colorida sale la
+/// captura. El lunes es el día de [fechaCapturas] y lleva cuatro ramos distintos, para
+/// que ni el horario ni "Clases de Hoy" queden en un solo tono.
 final List<(int, int, Asignatura)> _clasesMock = [
+  // Lunes
   (1, 1, computacionEnLaNube),
-  (3, 1, trabajoDeTitulo),
-  (5, 1, practicaProfesional),
-  (2, 2, computacionEnLaNube),
-  (6, 2, trabajoDeTitulo),
-  (1, 3, practicaProfesional),
-  (4, 3, computacionEnLaNube),
-  (3, 4, trabajoDeTitulo),
-  (5, 4, practicaProfesional),
-  (2, 5, computacionEnLaNube),
-  (4, 5, practicaProfesional),
+  (2, 1, computacionWebYMovil),
+  (4, 1, gestionDeProyectos),
+  (5, 1, electivoEspecializacion),
+  (6, 1, electivoEspecializacion),
+  // Martes
+  (1, 2, computacionEnLaNube),
+  (3, 2, electivoEspecializacion),
+  (4, 2, computacionWebYMovil),
+  (6, 2, practicaProfesional),
+  // Miércoles
+  (1, 3, computacionEnLaNube),
+  (2, 3, gestionDeProyectos),
+  (4, 3, computacionWebYMovil),
+  (5, 3, trabajoDeTitulo),
+  // Jueves
+  (3, 4, practicaProfesional),
+  (4, 4, computacionWebYMovil),
+  (5, 4, trabajoDeTitulo),
+  // Viernes
+  (1, 5, gestionDeProyectos),
+  (3, 5, gestionDeProyectos),
+  (4, 5, electivoEspecializacion),
 ];
 
 /// Horario de 18 medios bloques x 6 días, igual a la matriz que arma [HorarioService].
@@ -131,13 +190,22 @@ Grades notasMock(Asignatura asignatura) => switch (asignatura.codigo) {
     notaPresentacion: 6.6,
     notaFinal: 6.6,
   ),
-  _ => Grades(
+  "INFB900" => Grades(
     notasParciales: [
       REvaluacion(descripcion: "Informe de Práctica", porcentaje: 60, nota: 6.9),
       REvaluacion(descripcion: "Evaluación de la Empresa", porcentaje: 40, nota: 7.0),
     ],
     notaPresentacion: 6.9,
     notaFinal: 6.9,
+  ),
+  _ => Grades(
+    notasParciales: [
+      REvaluacion(descripcion: "Solemne 1", porcentaje: 35, nota: 5.9),
+      REvaluacion(descripcion: "Solemne 2", porcentaje: 35, nota: 6.1),
+      REvaluacion(descripcion: "Trabajos", porcentaje: 30, nota: 6.7),
+    ],
+    notaPresentacion: 6.2,
+    notaFinal: 6.2,
   ),
 };
 
@@ -150,22 +218,26 @@ AsignaturaMalla _inscrita(int nivel, String nombre, {String tipo = "Obligatoria"
 AsignaturaMalla _noCursada(int nivel, String nombre, {String tipo = "Obligatoria"}) =>
     AsignaturaMalla(nivel: nivel, nombre: nombre, tipo: tipo, intentos: 0, estado: "No Cursado", nota: "-");
 
-/// Malla de Ingeniería en Informática, con las tres asignaturas en curso inscritas
-/// y Trabajo de Título II todavía sin cursar.
+AsignaturaMalla _reprobada(int nivel, String nombre, String nota, {String tipo = "Obligatoria"}) =>
+    AsignaturaMalla(nivel: nivel, nombre: nombre, tipo: tipo, intentos: 1, estado: "Reprobado", nota: nota);
+
+/// Malla de Ingeniería en Informática, con las asignaturas en curso inscritas y Trabajo
+/// de Título II todavía sin cursar. Los niveles 1 y 2 llevan un ramo reprobado y dos
+/// inscritos (se están cursando de nuevo) para que la captura muestre los cuatro estados.
 final List<AsignaturaMalla> mallaMock = [
   // Nivel 1
   _aprobada(1, "Habilidades de Razonamiento Lógico", "6,2", tipo: "Nivelación"),
   _aprobada(1, "Taller de Ciencia y Tecnología", "4,5"),
   _aprobada(1, "Introducción a la Ingeniería en Informática", "6,0"),
   _aprobada(1, "Algoritmos y Programación", "6,4"),
-  _aprobada(1, "Taller de Matemática", "4,0"),
-  _aprobada(1, "Design Thinking", "5,0"),
+  _reprobada(1, "Taller de Matemática", "3,4"),
+  _inscrita(1, "Design Thinking"),
   // Nivel 2
   _aprobada(2, "Electivo de Formación General I", "6,0", tipo: "Electivo"),
   _aprobada(2, "Habilidades de Trabajo Académico", "5,4", tipo: "Nivelación"),
   _aprobada(2, "Cálculo Diferencial", "4,0"),
   _aprobada(2, "Estructuras de Datos", "5,1"),
-  _aprobada(2, "Mecánica Clásica", "4,2"),
+  _inscrita(2, "Mecánica Clásica"),
   _aprobada(2, "Álgebra Clásica", "4,4"),
   // Nivel 3
   _aprobada(3, "Electromagnetismo", "4,1"),
@@ -196,11 +268,11 @@ final List<AsignaturaMalla> mallaMock = [
   _aprobada(6, "Ingeniería de Software", "5,1"),
   // Nivel 7
   _aprobada(7, "Electivo de Formación Especializada I", "6,8", tipo: "Electivo"),
-  _aprobada(7, "Electivo de Formación Especializada II", "6,3", tipo: "Electivo"),
+  _inscrita(7, "Electivo de Formación Especializada II", tipo: "Electivo"),
   _inscrita(7, "Trabajo de Título I"),
-  _aprobada(7, "Gestión de Proyectos Informáticos", "5,1"),
+  _inscrita(7, "Gestión de Proyectos Informáticos"),
   _inscrita(7, "Computación en la Nube"),
-  _aprobada(7, "Computación Web y Móvil", "4,5"),
+  _inscrita(7, "Computación Web y Móvil"),
   // Nivel 8
   _noCursada(8, "Trabajo de Título II"),
   _inscrita(8, "Práctica Profesional"),

--- a/lib/core/services/controllers/horario_controller.dart
+++ b/lib/core/services/controllers/horario_controller.dart
@@ -56,7 +56,9 @@ class HorarioController {
     const Color(0xFFBA68C8), // Purple 300
   ];
 
-  final _randomColors = List<Color>.from(_pastelColors)..shuffle();
+  // En modo capturas la paleta va en su orden original: así cada corrida reparte los mismos
+  // colores entre los ramos y las capturas de la tienda no cambian de una compilación a otra.
+  final _randomColors = modoCapturas ? List<Color>.from(_pastelColors) : (List<Color>.from(_pastelColors)..shuffle());
   final _now = ahora();
 
   num daysCount = 6;

--- a/lib/core/services/service_manager.dart
+++ b/lib/core/services/service_manager.dart
@@ -4,6 +4,7 @@ import "package:firebase_core/firebase_core.dart" show Firebase, FirebaseOptions
 import "package:firebase_crashlytics/firebase_crashlytics.dart";
 import "package:flutter/cupertino.dart";
 import "package:get/get.dart";
+import "package:get_storage/get_storage.dart";
 import "package:miutem/core/mock/mock_services.dart";
 import "package:miutem/core/models/config/user_config.dart";
 import "package:miutem/core/repositories/secure_storage_repository.dart";
@@ -30,6 +31,10 @@ Future<void> initServices(FirebaseOptions firebaseOptions) async {
     FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
     return true;
   };
+
+  // Sin esto, GetStorage lee y escribe sobre un mapa vacío que se reemplaza cuando termina
+  // de cargar el archivo: los colores del horario se perdían y todos los ramos salían celestes.
+  await GetStorage.init();
 
   Get.lazyPut(() => RemoteConfigService());
   await Get.find<RemoteConfigService>().initialize();

--- a/lib/widgets/feature_flag.dart
+++ b/lib/widgets/feature_flag.dart
@@ -120,6 +120,10 @@ class FeatureFlag extends StatelessWidget {
 
   /// Internal method to evaluate nested feature flags from the JSON structure
   static bool _evaluateNestedFlag(FirebaseRemoteConfig remoteConfig, String flagKey) {
+    // En modo capturas se muestran todas las características, incluidas las que estén
+    // apagadas en Remote Config: las capturas de las tiendas tienen que mostrarlas.
+    if (modoCapturas) return true;
+
     try {
       // Get the feature_flags JSON from Remote Config
       final featureFlagsJson = remoteConfig.getString(RemoteConfigServiceKeys.featureFlags);

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -8,6 +8,16 @@ class MainFlutterWindow: NSWindow {
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)
 
+    // Tamaño exacto del área de Flutter, en puntos. Lo define el lane `mac screenshots`
+    // (MIUTEM_WINDOW_SIZE=1440x900) porque la Mac App Store sólo acepta capturas de
+    // 1280x800, 1440x900, 2560x1600 o 2880x1800: la ventana tiene que salir con esa forma.
+    let tamano = ProcessInfo.processInfo.environment["MIUTEM_WINDOW_SIZE"]?
+      .split(separator: "x").compactMap { Double($0) } ?? []
+    if tamano.count == 2 {
+      self.setContentSize(NSSize(width: tamano[0], height: tamano[1]))
+      self.center()
+    }
+
     RegisterGeneratedPlugins(registry: flutterViewController)
 
     super.awakeFromNib()

--- a/macos/fastlane/Fastfile
+++ b/macos/fastlane/Fastfile
@@ -168,6 +168,66 @@ platform :mac do
     end
   end
 
+  # Mismo recorrido que iOS y Android (integration_test/screenshots_test.dart con
+  # `flutter drive`), pero sin frameit: no existen marcos de Mac, y la Mac App Store
+  # recibe las capturas tal cual, sin fondo ni título.
+  desc "Genera las capturas de pantalla de macOS y las guarda en macos/fastlane/screenshots"
+  lane :screenshots do |options|
+    locale = string_option(options, :locale, env_var: "SCREENSHOT_LOCALE", default: "es-MX")
+    app_env = string_option(options, :app_env, env_var: "APP_ENV", default: "prod")
+    clear = bool_option(options, :clear, env_var: "SCREENSHOT_CLEAR", default: true)
+    # Tamaño de la ventana en puntos. 1440x900 es una de las formas que acepta la tienda y
+    # el recorrido rasteriza al doble, así las capturas salen en 2880x1800.
+    size = string_option(options, :size, env_var: "SCREENSHOT_MACOS_SIZE", default: "1440x900")
+
+    scheme = app_env == "prod" ? "production" : "development"
+    # APP_ENV suele quedar en dev en el .env local, y las capturas de la tienda tienen que
+    # salir del flavor de producción (nombre, ícono y bundle id distintos).
+    UI.important("⚠️  Capturando el flavor #{scheme}. Para la Mac App Store usa `app_env:prod`.") unless app_env == "prod"
+
+    # Ruta absoluta: el CWD de un lane es la carpeta fastlane/, no la raíz del repo.
+    root = sh("git", "rev-parse", "--show-toplevel", log: false).strip
+    output_dir = File.join(root, "macos", "fastlane", "screenshots", locale)
+
+    Dir.glob(File.join(output_dir, "*.png")).each { |captura| File.delete(captura) } if clear
+    FileUtils.mkdir_p(output_dir)
+
+    ENV["SCREENSHOTS_DIR"] = output_dir
+    ENV["SCREENSHOT_PREFIX"] = ""
+    # La lee MainFlutterWindow.swift al abrir la ventana.
+    ENV["MIUTEM_WINDOW_SIZE"] = size
+
+    # El paso de símbolos de Crashlytics que agrega flutterfire deduce la carpeta de
+    # paquetes de Swift desde $BUILD_ROOT (".../Build/Products") y busca ahí
+    # SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run. Eso calza con el
+    # DerivedData por defecto que usa iOS, pero `flutter build macos` pasa
+    # `-derivedDataPath build/macos` y ahí los checkouts quedan un nivel más arriba, así
+    # que el paso corta la compilación con "No such file or directory". El enlace deja el
+    # checkout donde el script lo espera (los lanes de despliegue no lo necesitan: compilan
+    # con xcodebuild y su DerivedData de siempre).
+    productos = File.join(root, "build", "macos", "Build", "Products")
+    FileUtils.mkdir_p(productos)
+    FileUtils.ln_sf(File.join(root, "build", "macos", "SourcePackages"), File.join(productos, "SourcePackages"))
+
+    # SCREENSHOT_MODE hace que la app use los datos ficticios de lib/core/mock/
+    # en vez de conectarse a SIGA y Mi.UTEM: no se necesita ninguna cuenta real.
+    sh(
+      "flutter", "drive",
+      "--driver=test_driver/integration_test.dart",
+      "--target=integration_test/screenshots_test.dart",
+      "--flavor", scheme,
+      "-d", "macos",
+      "--dart-define=SCREENSHOT_MODE=true",
+      "--dart-define=SCREENSHOT_PROD=#{app_env == 'prod'}"
+    )
+
+    # Un timeout del test igual reporta "All tests passed" sin escribir nada, así que se verifica el resultado.
+    capturas = Dir.glob(File.join(output_dir, "*.png"))
+    UI.user_error!("❌ No se generó ninguna captura. Revisa el log de `flutter drive`.") if capturas.empty?
+
+    UI.success("✅ #{capturas.length} capturas guardadas en #{output_dir}")
+  end
+
   desc "Carga la API Key de App Store Connect para autenticación"
   lane :load_api_key do |options|
     key_id = string_option(options, :key_id, env_var: "APP_STORE_CONNECT_API_KEY_ID", required: true)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: miutem
 description: "Plataforma académica para estudiantes de la Universidad Tecnológica Metropolitana (UTEM)"
 publish_to: none
 
-version: 4.0.0+157
+version: 4.0.0+158
 
 environment:
   sdk: ^3.11.1


### PR DESCRIPTION
Las capturas de macOS salen del mismo recorrido de integration_test, pero rasterizando la capa raíz de Flutter: el plugin de integration_test en macOS no implementa captureScreenshot. La ventana se abre en 1440x900 (MIUTEM_WINDOW_SIZE) y se rasteriza al doble, así las capturas quedan en 2880x1800, una de las formas que acepta la Mac App Store. No pasan por frameit porque no existen marcos de Mac.

El lane enlaza el checkout de SPM donde lo busca el paso de símbolos de Crashlytics: `flutter build macos` usa build/macos como derived data y ahí los checkouts quedan un nivel más arriba, con lo que la compilación se caía.

En modo capturas los feature flags de Remote Config se dan todos por activados, para que la ficha muestre también las características que estén apagadas.

Los colores del horario se perdían porque nunca se llamaba a GetStorage.init(): el controlador escribía sobre un mapa que se reemplazaba al terminar de cargar el archivo, y todos los ramos salían del mismo celeste por defecto. Con eso resuelto, el mock pasa a seis asignaturas repartidas de lunes a viernes y la paleta va en orden fijo, para que cada corrida reparta los mismos colores. La malla suma un ramo reprobado y dos inscritos en los niveles 1 y 2.