### PR TITLE
feat(macos): se enmarcan las capturas con fondo y textos

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -484,6 +484,10 @@ jobs:
     timeout-minutes: 60
     # Si contiene [skip deploy] o [skip screenshots] en el mensaje del commit, se saltará.
     if: ${{ !contains(github.event.head_commit.message, '[skip deploy]') && !contains(github.event.head_commit.message, '[skip screenshots]') }}
+    env:
+      # Los títulos de las capturas llevan tildes y el runner de macOS no define locale.
+      LANG: en_US.UTF-8
+      LC_ALL: en_US.UTF-8
     steps:
       - name: 📚 Clonar Repositorio
         uses: actions/checkout@v4
@@ -509,6 +513,10 @@ jobs:
             ~/.cocoapods
           key: pods-screenshots-macos-${{ runner.os }}-${{ hashFiles('macos/Podfile.lock') }}
           restore-keys: pods-screenshots-macos-${{ runner.os }}-
+
+      - name: 🪄 Instalar ImageMagick
+        # Los scripts de fondos y de enmarcado trabajan con `magick`.
+        run: brew install imagemagick
 
       - name: 🐦 Configurar Flutter SDK
         uses: flutter-actions/setup-flutter@v4
@@ -568,7 +576,7 @@ jobs:
           {
             echo "## 📸 Capturas de pantalla (macOS)"
             echo ""
-            echo "- $(find macos/fastlane/screenshots -name '*.png' | wc -l | tr -d ' ') capturas de 2880x1800 para la Mac App Store"
+            echo "- $(find macos/fastlane/screenshots -name '*_framed.png' | wc -l | tr -d ' ') capturas enmarcadas de 2880x1800 para la Mac App Store"
             echo "- [Descargar artefacto]($ARTEFACTO_URL)"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/macos/fastlane/Fastfile
+++ b/macos/fastlane/Fastfile
@@ -169,13 +169,16 @@ platform :mac do
   end
 
   # Mismo recorrido que iOS y Android (integration_test/screenshots_test.dart con
-  # `flutter drive`), pero sin frameit: no existen marcos de Mac, y la Mac App Store
-  # recibe las capturas tal cual, sin fondo ni título.
+  # `flutter drive`), y el mismo acabado —fondo, titular y subtítulo—, pero sin frameit: su
+  # editor de Mac no dibuja marco y encima nunca corre, porque busca el dispositivo por el
+  # nombre "MacBook" y el de su lista es "Apple MacBook". Lo arma
+  # scripts/frame-macos-screenshots, que además le pone la ventana de macOS.
   desc "Genera las capturas de pantalla de macOS y las guarda en macos/fastlane/screenshots"
   lane :screenshots do |options|
     locale = string_option(options, :locale, env_var: "SCREENSHOT_LOCALE", default: "es-MX")
     app_env = string_option(options, :app_env, env_var: "APP_ENV", default: "prod")
     clear = bool_option(options, :clear, env_var: "SCREENSHOT_CLEAR", default: true)
+    frame = bool_option(options, :frame, env_var: "SCREENSHOT_FRAME", default: true)
     # Tamaño de la ventana en puntos. 1440x900 es una de las formas que acepta la tienda y
     # el recorrido rasteriza al doble, así las capturas salen en 2880x1800.
     size = string_option(options, :size, env_var: "SCREENSHOT_MACOS_SIZE", default: "1440x900")
@@ -258,7 +261,18 @@ platform :mac do
     capturas = Dir.glob(File.join(output_dir, "*.png"))
     UI.user_error!("❌ No se generó ninguna captura. Revisa el log de `flutter drive`.") if capturas.empty?
 
-    UI.success("✅ #{capturas.length} capturas guardadas en #{output_dir}")
+    if frame
+      # Los fondos se cortan al tamaño exacto de las capturas y una tira por captura, así
+      # que se generan después del recorrido: si cambia el tamaño de la ventana o el número
+      # de pantallas, las tiras dejarían de calzar y se perdería la continuidad de la foto.
+      sh(File.join(root, "scripts", "generate-screenshot-backgrounds"), "macos")
+      sh(File.join(root, "scripts", "frame-macos-screenshots"), locale)
+
+      capturas = Dir.glob(File.join(output_dir, "*_framed.png"))
+      UI.user_error!("❌ No se generó ninguna captura enmarcada.") if capturas.empty?
+    end
+
+    UI.success("✅ #{capturas.length} capturas #{frame ? 'enmarcadas' : 'guardadas'} en #{output_dir}")
   end
 
   desc "Carga la API Key de App Store Connect para autenticación"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: miutem
 description: "Plataforma académica para estudiantes de la Universidad Tecnológica Metropolitana (UTEM)"
 publish_to: none
 
-version: 4.0.0+160
+version: 4.0.0+161
 
 environment:
   sdk: ^3.11.1

--- a/scripts/frame-macos-screenshots
+++ b/scripts/frame-macos-screenshots
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Enmarca las capturas de macOS como las de iOS y Android: el mismo fondo panorámico, el
+# mismo par titular/subtítulo arriba, y la captura dentro de una ventana de macOS (barra de
+# título con semáforos, esquinas redondeadas y sombra). Deja los *_framed.png al lado.
+#
+# No lo hace frameit, aunque tenga un MacEditor: ese editor sólo pega la captura sobre el
+# fondo ("Macs don't need frames - backgrounds only") y encima nunca llega a correr, porque
+# reconoce al Mac comparando el nombre del dispositivo con "MacBook" y el de su propia lista
+# es "Apple MacBook"; la captura termina tratada como un iPhone sin marco y frameit se va
+# sin escribir nada.
+#
+# Se ejecuta después de `scripts/generate-screenshot-backgrounds macos`, que es quien deja
+# las tiras de fondo con el nombre de cada captura.
+#
+# Uso: scripts/frame-macos-screenshots [locale]
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+BASE="macos/fastlane/screenshots"
+TEXTOS="fastlane/screenshots" # Los titulares son los de iOS: son las mismas pantallas.
+FUENTE_TEXTO="fastlane/screenshots/fonts/Roboto.ttf"
+
+# Las medidas van en fracciones del alto de la captura —el lado corto, porque es apaisada—
+# para que el resultado no dependa del tamaño en que se hayan tomado.
+CUERPO_TITULAR=0.064    # Mismo cuerpo relativo que el Framefile de iOS (84 sobre 1320).
+CUERPO_SUBTITULO=0.037
+COLOR_TITULAR="#FFFFFF"
+COLOR_SUBTITULO="#CFE8DC"
+MARGEN_SUPERIOR=0.055   # Del borde de arriba al titular.
+ESPACIO_BAJO_TEXTO=0.05 # Del subtítulo a la ventana.
+MARGEN_INFERIOR=0.08    # Tiene que dar para la sombra, o se corta contra el borde.
+ANCHO_VENTANA=0.80      # Ancho máximo de la ventana, en anchos de captura.
+BARRA=0.038             # Alto de la barra de título.
+RADIO=0.012             # Radio de las esquinas de la ventana.
+SOMBRA=0.022            # Desenfoque de la sombra.
+SOMBRA_OPACIDAD=0.6
+
+command -v magick >/dev/null || { echo "❌ Falta ImageMagick (brew install imagemagick)" >&2; exit 1; }
+
+calc() { python3 -c "print(round($1))"; }
+
+# Valor de una clave en un archivo .strings, en una sola línea: los \n de esos textos están
+# puestos para las pantallas verticales de iOS y Android, y acá sobra ancho.
+texto_de() {
+  sed -n "s/^\"$2\" = \"\(.*\)\";$/\1/p" "$1" | sed 's/\\n/ /g'
+}
+
+LOCALE="${1:-es-MX}"
+DIR="$BASE/$LOCALE"
+
+capturas=()
+while IFS= read -r captura; do capturas+=("$captura"); done \
+  < <(find "$DIR" -name "*.png" ! -name "*_framed.png" 2>/dev/null | sort)
+[ "${#capturas[@]}" -gt 0 ] || { echo "❌ No hay capturas en $DIR: genéralas antes." >&2; exit 1; }
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+for captura in "${capturas[@]}"; do
+  clave=$(basename "$captura" .png)
+
+  read -r ancho alto <<<"$(magick identify -format "%w %h" "$captura")"
+
+  fondo="$BASE/backgrounds/$clave.jpg"
+  [ -f "$fondo" ] || fondo="$BASE/background.jpg"
+  [ -f "$fondo" ] || { echo "❌ Falta el fondo de $clave: corre generate-screenshot-backgrounds macos" >&2; exit 1; }
+
+  titular=$(texto_de "$TEXTOS/$LOCALE/keyword.strings" "$clave")
+  subtitulo=$(texto_de "$TEXTOS/$LOCALE/title.strings" "$clave")
+  [ -n "$titular" ] || { echo "❌ Falta el titular de $clave en $TEXTOS/$LOCALE/keyword.strings" >&2; exit 1; }
+  [ -n "$subtitulo" ] || { echo "❌ Falta el subtítulo de $clave en $TEXTOS/$LOCALE/title.strings" >&2; exit 1; }
+
+  # 1. La barra de título, del color del borde superior de la captura: la app dibuja hasta
+  # el tope de la ventana, así que la barra sale del mismo color que lo que queda debajo,
+  # igual que en pantalla. Va sin el nombre de la ventana: quedaría justo encima del título
+  # de la pantalla que ya dibuja la app, y los semáforos solos se leen igual de bien.
+  barra=$(calc "$alto * $BARRA")
+  color_barra=$(magick "$captura" -crop "${ancho}x8+0+0" +repage -resize 1x1! \
+    -format "%[pixel:p{0,0}]" info:)
+
+  # Los semáforos, con las medidas de macOS (12 pt de diámetro, 20 pt entre centros y del
+  # borde) llevadas a la escala de la barra, que en el sistema mide 28 pt.
+  radio_boton=$(calc "$barra * 12 / 28 / 2")
+  paso=$(calc "$barra * 20 / 28")
+  centro=$(calc "$barra / 2")
+
+  magick -size "${ancho}x${barra}" "xc:$color_barra" \
+    -fill "#FF5F57" -draw "circle $paso,$centro $((paso + radio_boton)),$centro" \
+    -fill "#FEBC2E" -draw "circle $((paso * 2)),$centro $((paso * 2 + radio_boton)),$centro" \
+    -fill "#28C840" -draw "circle $((paso * 3)),$centro $((paso * 3 + radio_boton)),$centro" \
+    "$tmp/barra.png"
+
+  # 2. La ventana: barra más captura, recortada con las esquinas redondeadas del sistema.
+  alto_marco=$((barra + alto))
+  radio=$(calc "$alto * $RADIO")
+  magick "$tmp/barra.png" "$captura" -append \
+    \( -size "${ancho}x${alto_marco}" xc:none -fill white \
+       -draw "roundrectangle 0,0,$((ancho - 1)),$((alto_marco - 1)),$radio,$radio" \) \
+    -alpha set -compose DstIn -composite "$tmp/ventana.png"
+
+  # 3. El texto, con el mismo par titular/subtítulo del resto de las tiendas. El espacio
+  # entre los dos se hace con -splice y no con una imagen vacía: el -size de esa imagen se
+  # quedaría pegado y recortaría el label siguiente.
+  cuerpo_titular=$(calc "$alto * $CUERPO_TITULAR")
+  cuerpo_subtitulo=$(calc "$alto * $CUERPO_SUBTITULO")
+  magick -background none -font "$FUENTE_TEXTO" \
+    \( -fill "$COLOR_TITULAR" -pointsize "$cuerpo_titular" -gravity center label:"$titular" \) \
+    \( -fill "$COLOR_SUBTITULO" -pointsize "$cuerpo_subtitulo" -gravity center label:"$subtitulo" \
+       -gravity north -splice "0x$((cuerpo_titular / 2))" \) \
+    -gravity center -append +repage \
+    -resize "$(calc "$ancho * 0.9")x>" \
+    "$tmp/texto.png"
+
+  # 4. La ventana, achicada a lo que queda libre bajo el texto.
+  alto_texto=$(magick identify -format "%h" "$tmp/texto.png")
+  arriba_texto=$(calc "$alto * $MARGEN_SUPERIOR")
+  arriba_ventana=$((arriba_texto + alto_texto + $(calc "$alto * $ESPACIO_BAJO_TEXTO")))
+  alto_libre=$((alto - arriba_ventana - $(calc "$alto * $MARGEN_INFERIOR")))
+  magick "$tmp/ventana.png" -resize "$(calc "$ancho * $ANCHO_VENTANA")x${alto_libre}" "$tmp/ventana_final.png"
+
+  # 5. La sombra, dentro de un margen fijo para saber cuánto crece el conjunto y poder
+  # centrarlo después.
+  desenfoque=$(calc "$alto * $SOMBRA")
+  caida=$(calc "$desenfoque * 0.8")
+  margen=$(calc "$desenfoque * 2.5 + $caida")
+  read -r ancho_ventana alto_ventana <<<"$(magick identify -format "%w %h" "$tmp/ventana_final.png")"
+  magick -size "$((ancho_ventana + margen * 2))x$((alto_ventana + margen * 2))" xc:none \
+    \( "$tmp/ventana_final.png" -fill black -colorize 100 \
+       -channel A -evaluate multiply "$SOMBRA_OPACIDAD" +channel \
+       -bordercolor none -border "$margen" -blur "0x$desenfoque" \) \
+    -gravity northwest -geometry "+0+$caida" -composite \
+    "$tmp/ventana_final.png" -gravity northwest -geometry "+$margen+$margen" -composite \
+    "$tmp/conjunto.png"
+
+  # 6. Todo junto sobre la tira de fondo que le toca a esta captura.
+  read -r ancho_conjunto _ <<<"$(magick identify -format "%w %h" "$tmp/conjunto.png")"
+  magick "$fondo" -resize "${ancho}x${alto}^" -gravity center -extent "${ancho}x${alto}" \
+    "$tmp/conjunto.png" -gravity northwest \
+      -geometry "+$(((ancho - ancho_conjunto) / 2))+$((arriba_ventana - margen))" -composite \
+    "$tmp/texto.png" -gravity north -geometry "+0+$arriba_texto" -composite \
+    "$DIR/${clave}_framed.png"
+done
+
+echo "✅ ${#capturas[@]} capturas enmarcadas en $DIR"

--- a/scripts/generate-screenshot-backgrounds
+++ b/scripts/generate-screenshot-backgrounds
@@ -3,7 +3,7 @@
 # en tiras verticales, una por captura. Puestas lado a lado en la ficha de la tienda,
 # las capturas reconstruyen la foto completa.
 #
-# Uso: scripts/generate-screenshot-backgrounds [ios|android|all]
+# Uso: scripts/generate-screenshot-backgrounds [ios|android|macos|all]
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
@@ -31,24 +31,39 @@ panoramica() {
     -quality 88 "$destino"
 }
 
-# generar <carpeta de screenshots> <locale> <ancho por defecto> <alto por defecto>
+# Capturas ya tomadas de una carpeta, en el orden en que van en la ficha. El `|| true` es
+# para la carpeta que todavía no existe: con `pipefail` el find fallido cortaría el script
+# sin decir nada, y quien pregunta por las capturas es justamente quien sabe si faltan.
+capturas_de() {
+  find "$1" -name "*.png" ! -name "*_framed.png" 2>/dev/null | sort || true
+}
+
+# generar <carpeta de screenshots> <locale> <ancho por defecto> <alto por defecto> [claves]
+#
+# Las claves salen de title.strings salvo que se pida `capturas`: macOS reusa los textos de
+# iOS y no tiene capturas compuestas aparte, así que ahí las claves son las que hay tomadas.
 generar() {
-  local base=$1 locale=$2 ancho=$3 alto=$4
+  local base=$1 locale=$2 ancho=$3 alto=$4 origen=${5:-strings}
 
   # Las capturas ya tomadas mandan sobre el tamaño por defecto: si el alto no calza
   # con el de la captura, frameit reescala y recorta el fondo y se pierde la continuidad.
   local muestra
-  muestra=$(find "$base/$locale" -name "*.png" ! -name "*_framed.png" | sort | head -1 || true)
+  muestra=$(capturas_de "$base/$locale" | head -1)
   if [ -n "$muestra" ]; then
     read -r ancho alto <<<"$(magick identify -format "%w %h" "$muestra")"
   fi
 
   # El orden lo define title.strings, que es el mismo con el que se suben las capturas.
   local claves=()
-  while IFS= read -r clave; do claves+=("$clave"); done \
-    < <(grep -o '^"[^"]*"' "$base/$locale/title.strings" | tr -d '"')
+  if [ "$origen" = capturas ]; then
+    while IFS= read -r captura; do claves+=("$(basename "$captura" .png)"); done \
+      < <(capturas_de "$base/$locale")
+  else
+    while IFS= read -r clave; do claves+=("$clave"); done \
+      < <(grep -o '^"[^"]*"' "$base/$locale/title.strings" | tr -d '"')
+  fi
   local n=${#claves[@]}
-  [ "$n" -gt 0 ] || { echo "❌ $base/$locale/title.strings no tiene claves" >&2; exit 1; }
+  [ "$n" -gt 0 ] || { echo "❌ No hay claves para los fondos de $base/$locale: revisa las capturas y title.strings" >&2; exit 1; }
 
   local tiras="$base/backgrounds"
   rm -rf "$tiras" && mkdir -p "$tiras"
@@ -72,9 +87,17 @@ generar() {
 
 PLATAFORMA="${1:-all}"
 case "$PLATAFORMA" in
-  ios|android|all) ;;
-  *) echo "❌ Uso: $(basename "$0") [ios|android|all]" >&2; exit 1 ;;
+  ios|android|macos|all) ;;
+  *) echo "❌ Uso: $(basename "$0") [ios|android|macos|all]" >&2; exit 1 ;;
 esac
 
-[ "$PLATAFORMA" = android ] || generar "fastlane/screenshots" "es-MX" 1320 2868
-[ "$PLATAFORMA" = ios ] || generar "android/fastlane/screenshots" "es-419" 1080 2160
+case "$PLATAFORMA" in ios|all) generar "fastlane/screenshots" "es-MX" 1320 2868 ;; esac
+case "$PLATAFORMA" in android|all) generar "android/fastlane/screenshots" "es-419" 1080 2160 ;; esac
+# macOS necesita capturas ya tomadas, que de ahí saca las claves. Sin ellas no hay nada que
+# cortar: pedido a mano se avisa, y en `all` se salta, que es lo normal si sólo se corrió el
+# recorrido de iOS o de Android.
+case "$PLATAFORMA" in
+  macos) generar "macos/fastlane/screenshots" "es-MX" 2880 1800 capturas ;;
+  all) [ -z "$(capturas_de macos/fastlane/screenshots/es-MX)" ] \
+    || generar "macos/fastlane/screenshots" "es-MX" 2880 1800 capturas ;;
+esac


### PR DESCRIPTION
## Qué cambia

Las capturas de macOS ahora pasan por el mismo acabado que las de iOS y Android: fondo panorámico, titular y subtítulo, y la captura dentro de un marco. Antes salían crudas del recorrido, sin nada.

| Antes | Ahora |
| --- | --- |
| La captura de la app tal cual, 2880x1800 | La misma captura dentro de una ventana de macOS, sobre su tira de la foto de fondo y con el par titular/subtítulo arriba |

## Por qué no lo hace frameit

Tiene un `MacEditor`, pero no dibuja marco por diseño (`load_frame` devuelve nil: *"Macs don't need frames - backgrounds only"*) y encima nunca llega a correr: reconoce al Mac con `device_name == "MacBook"` y el nombre en su propia lista de dispositivos es `"Apple MacBook"`, así que la captura termina tratada como un iPhone sin plantilla y frameit se va sin escribir nada.

## Detalle

- **`scripts/frame-macos-screenshots`** (nuevo): arma la ventana de macOS con ImageMagick —barra de título con semáforos, del color del borde superior de la captura porque la app dibuja hasta el tope de la ventana; esquinas redondeadas y sombra—, la centra sobre la tira de fondo que le toca y le agrega los textos con el mismo cuerpo relativo, fuente y colores que el Framefile de iOS. Deja los `*_framed.png` de 2880x1800, que es lo que acepta la Mac App Store.
- **`scripts/generate-screenshot-backgrounds`**: acepta `macos`. Las claves salen de las capturas ya tomadas, porque macOS no tiene `title.strings` propio ni las dos capturas compuestas aparte; en `all` se salta si todavía no hay capturas.
- **`macos/fastlane/Fastfile`**: el lane `mac screenshots` corre los dos scripts al terminar el recorrido y falla si no quedó ninguna captura enmarcada. Se desactiva con `frame:false` o `SCREENSHOT_FRAME=false`.
- **`.github/workflows/deploy.yml`**: al job `screenshots-macos` le faltaba ImageMagick; también lleva `LANG`/`LC_ALL` (los títulos tienen tildes y el runner no define locale, que es lo que ya rompía frameit en el job de iOS) y el resumen cuenta las enmarcadas.

## Para el reviewer

- El marco es una **ventana de macOS**, no un MacBook completo: es lo que usan las fichas de la Mac App Store, y en 16:10 un portátil entero dejaría la app diminuta. La geometría está toda en constantes al principio del script, en fracciones del alto de la captura.
- Los titulares se leen de `fastlane/screenshots/es-MX/` en vez de duplicarlos: son las mismas pantallas que en iOS. Los `\n` de esos textos, puestos para pantallas verticales, se convierten en espacios.
- **Sin probar de punta a punta**: el recorrido real de `flutter drive` en macOS no se corrió. Sí se verificó el enmarcado con capturas sintéticas de 2880x1800 (claras y oscuras, con y sin locale UTF-8), que la salida mantiene el tamaño exacto y que los fondos de iOS y Android se regeneran byte a byte idénticos.
- No se agregó lane de subida para macOS: no existía antes de este cambio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)